### PR TITLE
docs: Add branch protection information to documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,6 +59,12 @@ git push origin feat/my-new-feature
 gh pr create
 ```
 
+**Important:** The `main` branch is protected and requires:
+- ✅ All CI checks must pass (Ansible lint, YAML lint, security scans, etc.)
+- ✅ Changes must be submitted via Pull Request
+- ✅ All PR conversations must be resolved
+- ⚠️ Direct pushes to `main` are blocked
+
 ## Commit Message Format
 
 ### Structure

--- a/README.md
+++ b/README.md
@@ -585,6 +585,15 @@ Contributions are welcome! This project uses [Conventional Commits](https://www.
 - [Commit Convention](.github/COMMIT_CONVENTION.md) - Quick reference for commit messages
 - [Pull Request Template](.github/PULL_REQUEST_TEMPLATE.md) - PR checklist
 
+### Branch Protection
+
+The `main` branch is protected to ensure code quality:
+
+- 🔒 **Direct pushes blocked** - All changes must go through Pull Requests
+- ✅ **Required CI checks** - All linting and security scans must pass
+- 💬 **Conversation resolution** - All PR discussions must be resolved before merging
+- 🚫 **Force pushes disabled** - Prevents accidental history rewriting
+
 All PRs must:
 - ✅ Follow conventional commit format
 - ✅ Pass all CI checks (linting, security, tests)


### PR DESCRIPTION
## Description

Documents the newly enabled branch protection rules for the main branch.

## Changes
- Added branch protection section to README
- Updated CONTRIBUTING.md with branch protection requirements
- Clarified that all changes must go through PRs

## Type of Change
- [x] 📚 Documentation update

## Checklist
- [x] Follows conventional commit format
- [x] Documentation updated
- [x] Pre-commit hooks passed