### PR TITLE
fix(ci): Update release workflow to work with protected main branch

### DIFF
--- a/.github/workflows/ci-lint.yml
+++ b/.github/workflows/ci-lint.yml
@@ -3,9 +3,9 @@ name: CI - Lint and Validate
 
 on:
   push:
-    branches: [ main ]
+    branches: [main]
   pull_request:
-    branches: [ main ]
+    branches: [main]
   workflow_dispatch:
 
 permissions:
@@ -23,7 +23,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.11'
+          python-version: "3.11"
 
       - name: Install Ansible and ansible-lint
         run: |
@@ -48,7 +48,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.11'
+          python-version: "3.11"
 
       - name: Install yamllint
         run: |
@@ -69,7 +69,7 @@ jobs:
       - name: Run markdownlint
         uses: DavidAnson/markdownlint-cli2-action@v16
         with:
-          globs: '**/*.md'
+          globs: "**/*.md"
 
   ansible-syntax-check:
     name: Ansible Syntax Check
@@ -81,7 +81,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.11'
+          python-version: "3.11"
 
       - name: Install Ansible
         run: |
@@ -106,9 +106,9 @@ jobs:
       - name: Run ShellCheck
         uses: ludeeus/action-shellcheck@master
         with:
-          scandir: './roles'
+          scandir: "./roles"
           severity: warning
-          ignore_paths: '*.md'
+          ignore_paths: "*.md"
 
   security-scan:
     name: Security Scan
@@ -120,16 +120,16 @@ jobs:
       - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@master
         with:
-          scan-type: 'config'
-          scan-ref: '.'
-          format: 'sarif'
-          output: 'trivy-results.sarif'
+          scan-type: "config"
+          scan-ref: "."
+          format: "sarif"
+          output: "trivy-results.sarif"
 
       - name: Upload Trivy results to GitHub Security tab
         uses: github/codeql-action/upload-sarif@v3
         if: always()
         with:
-          sarif_file: 'trivy-results.sarif'
+          sarif_file: "trivy-results.sarif"
 
   check-secrets:
     name: Check for Secrets
@@ -158,7 +158,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: "20"
 
       - name: Install commitlint
         run: |
@@ -171,7 +171,17 @@ jobs:
   all-checks-passed:
     name: All Checks Passed
     runs-on: ubuntu-latest
-    needs: [ansible-lint, yaml-lint, markdown-lint, ansible-syntax-check, shellcheck, security-scan, check-secrets, commitlint]
+    needs:
+      [
+        ansible-lint,
+        yaml-lint,
+        markdown-lint,
+        ansible-syntax-check,
+        shellcheck,
+        security-scan,
+        check-secrets,
+        commitlint,
+      ]
     if: always()
     steps:
       - name: Check if all jobs passed

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       release-type:
-        description: 'Release type'
+        description: "Release type"
         required: true
         type: choice
         options:
@@ -12,7 +12,7 @@ on:
           - patch
           - minor
           - major
-        default: 'auto'
+        default: "auto"
 
 permissions:
   contents: write
@@ -26,12 +26,14 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
+          # Use PAT to bypass branch protection for automated releases
+          # Falls back to GITHUB_TOKEN if PAT is not configured
+          token: ${{ secrets.PAT_TOKEN || secrets.GITHUB_TOKEN }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: "20"
 
       - name: Install dependencies
         run: npm install

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -132,6 +132,20 @@ Runs on every push and PR.
 
 ## Release Process
 
+### Prerequisites
+
+**Important:** Since the `main` branch is protected, you must set up a Personal Access Token (PAT) first:
+
+1. Create a fine-grained PAT at <https://github.com/settings/tokens?type=beta>
+   - Name: `homeassistant-pi5-kiosk-releases`
+   - Repository: `homeassistant-pi5-kiosk` only
+   - Permissions: Contents (read/write), Pull requests (read/write)
+2. Add to repository secrets as `PAT_TOKEN`
+   - Go to: Repository Settings → Secrets and variables → Actions
+   - Create secret named `PAT_TOKEN` with your token value
+
+Without this token, the release workflow cannot push to the protected `main` branch.
+
 ### Automated Release (Recommended)
 
 Releases are handled automatically via GitHub Actions:

--- a/README.md
+++ b/README.md
@@ -153,6 +153,7 @@ The repository includes automatic weekly maintenance via GitHub Actions.
    - Go to `Settings → Secrets and variables → Actions`
    - **Required secrets:**
      - `KIOSK_PASSWORD` - Kiosk user password
+     - `PAT_TOKEN` - Personal Access Token for automated releases (see [Release Setup](#automated-releases) below)
    - **Optional secrets** (will use defaults from playbook if not set):
      - `KIOSK_URL` - Home Assistant dashboard URL
      - `HOME_ASSISTANT_IP` - Home Assistant IP address (also used for failure webhook notifications)
@@ -475,6 +476,28 @@ Releases are automated via GitHub Actions workflow:
 2. **Changelog Generation**: Automatically generated from commit messages
 
 3. **GitHub Release**: Creates a GitHub release with changelog
+
+#### Setup: Create Personal Access Token (Required)
+
+Since the `main` branch is protected, automated releases need a Personal Access Token (PAT) to bypass branch protection:
+
+1. **Create a Personal Access Token:**
+   - Go to: <https://github.com/settings/tokens?type=beta>
+   - Click "Generate new token" (Fine-grained token recommended)
+   - Set token name: `homeassistant-pi5-kiosk-releases`
+   - Set expiration: 90 days (or longer)
+   - Repository access: Select "Only select repositories" → Choose `homeassistant-pi5-kiosk`
+   - Permissions:
+     - **Contents**: Read and write access
+     - **Pull requests**: Read and write access
+   - Click "Generate token" and **copy the token**
+
+2. **Add token to repository secrets:**
+   - Go to: <https://github.com/jcoetsie/homeassistant-pi5-kiosk/settings/secrets/actions>
+   - Click "New repository secret"
+   - Name: `PAT_TOKEN`
+   - Value: Paste your token
+   - Click "Add secret"
 
 #### Trigger a Release
 

--- a/roles/github_runner/tasks/main.yaml
+++ b/roles/github_runner/tasks/main.yaml
@@ -28,7 +28,7 @@
     state: directory
     owner: github-runner
     group: github-runner
-    mode: '0755'
+    mode: "0755"
   when: not github_runner_dir.stat.exists
 
 - name: Get latest GitHub runner version

--- a/roles/vnc/tasks/main.yaml
+++ b/roles/vnc/tasks/main.yaml
@@ -16,14 +16,14 @@
     state: directory
     owner: root
     group: root
-    mode: '0755'
+    mode: "0755"
 
 - name: Configure VNC authentication to use VncAuth
   ansible.builtin.copy:
     dest: /root/.vnc/config.d/vncserver-x11
     owner: root
     group: root
-    mode: '0644'
+    mode: "0644"
     content: |
       Authentication=VncAuth
       Encryption=PreferOn


### PR DESCRIPTION
## Description

Fixes the release workflow to work with the newly protected main branch by adding support for a Personal Access Token (PAT).

## Problem
The automated release workflow failed because:
```
remote: error: GH006: Protected branch update failed for refs/heads/main.
remote: - Changes must be made through a pull request.
```

## Solution
- Updated release workflow to use `PAT_TOKEN` secret (falls back to `GITHUB_TOKEN` if not set)
- Added comprehensive documentation for creating and configuring the PAT
- Updated both README and CONTRIBUTING.md with setup instructions

## Changes
- `.github/workflows/release.yml`: Use PAT_TOKEN for checkout
- `README.md`: Added PAT setup section under Automated Releases
- `CONTRIBUTING.md`: Added Prerequisites section for release process

## Type of Change
- [x] 🐛 Bug fix (fixes release workflow)
- [x] 📚 Documentation update

## Testing
- [ ] Create PAT token after this PR merges
- [ ] Add PAT_TOKEN to repository secrets
- [ ] Trigger release workflow to verify it works

## Checklist
- [x] Follows conventional commit format
- [x] Documentation updated
- [x] Pre-commit hooks passed
- [x] All CI checks will pass